### PR TITLE
styled images to fit their container and zoom on hover

### DIFF
--- a/client/src/components/MemberPreview.scss
+++ b/client/src/components/MemberPreview.scss
@@ -8,12 +8,21 @@ $title-color: #222;
 
 	.member-photo-container{
 		width: 100%;
+		height: 300px;
 		border-radius: 5px;
 		margin-bottom: 10px;
+		overflow: hidden;
 
 		.member-photo {
 			width: 100%;
-			object-fit: fill;
+			height: 100%;
+			object-fit: cover;
+			object-position: 50% 50%;
+		}
+
+		.member-photo:hover {
+			transition: 0.5s ease;
+			transform: scale(1.3);
 		}
 	}
 

--- a/client/src/components/MemberPreview.scss
+++ b/client/src/components/MemberPreview.scss
@@ -18,11 +18,11 @@ $title-color: #222;
 			height: 100%;
 			object-fit: cover;
 			object-position: 50% 50%;
-		}
 
-		.member-photo:hover {
-			transition: 0.5s ease;
-			transform: scale(1.3);
+			&:hover {
+				transition: 0.5s ease;
+				transform: scale(1.3);
+			}
 		}
 	}
 


### PR DESCRIPTION
The image css stuff me and Reece were doing on Friday. Images should now all appear as the correct size and zoom in on hover. I couldn't test properly as I didn't have the actual images and didn't have the database data. It's only css but heres a pull request just in case I missed something.