### PR TITLE
refactored logic to manage undefined members on featuredMembers page

### DIFF
--- a/src/components/FeaturedMembers/index.jsx
+++ b/src/components/FeaturedMembers/index.jsx
@@ -21,7 +21,7 @@ class FeaturedMembers extends React.Component {
 	prepareMembers(){
 		let members = [this.props.members[0], this.props.members[1], this.props.members[4]];
 		for(let index in members){
-			if(!members[index]) members[index] = {donations: []};
+			if(!members[index]) return [];
 		}
 		return members
 	}


### PR DESCRIPTION
Just slightly change the way the featured members page handles members if we select one that is undefined. This way seemed less hacky that what I did before.