### PR TITLE
Feature/centred member previews

### DIFF
--- a/src/Shared/components/MemberPreview/MemberPreview.scss
+++ b/src/Shared/components/MemberPreview/MemberPreview.scss
@@ -3,15 +3,15 @@ $button-color: #7663f6;
 
 
 .member-previews-one-column{
-	width: 30%;
+	width: 80%;
 }
 
 .member-previews-two-column{
-	width: 40%;
+	width: 45%;
 }
 
 .member-previews-three-column{
-	width: 50%;
+	width: 30%;
 }
 
 .member-preview {

--- a/src/Shared/components/MemberPreview/MemberPreview.scss
+++ b/src/Shared/components/MemberPreview/MemberPreview.scss
@@ -2,8 +2,19 @@ $button-color: #7663f6;
 // $button-color: #925ebc;
 
 
-.member-preview {
+.member-previews-one-column{
 	width: 30%;
+}
+
+.member-previews-two-column{
+	width: 40%;
+}
+
+.member-previews-three-column{
+	width: 50%;
+}
+
+.member-preview {
 	background-color: #fff;
 	border-radius: 7px;
 
@@ -54,7 +65,7 @@ $button-color: #7663f6;
 	}
 
 	.member-link {
-			
+
 			color: #333333;
 		}
 	.member-name {
@@ -100,7 +111,7 @@ $button-color: #7663f6;
 		.charity-link {
 			color: #999;
 			text-decoration: none;
-				
+
 				&:hover {
 					text-decoration: underline;
 				}
@@ -166,7 +177,7 @@ $button-color: #7663f6;
 				border-left: solid 1px #7b5dff;
 				padding-left: 10px;
 
-				
+
 
 
 				.goal-amount {
@@ -177,7 +188,7 @@ $button-color: #7663f6;
 					font-size: 0.55em;
 					font-weight: 300;
 
-					
+
 				}
 			}
 
@@ -199,10 +210,10 @@ $button-color: #7663f6;
 
 			&:hover {
 				background-color: $button-color;
-				color: #fff; 
+				color: #fff;
 				cursor: pointer;
 
-			}  
+			}
 		}
 
 	}
@@ -218,14 +229,14 @@ $button-color: #7663f6;
 
 				img {
 					height: 22px;
-					padding-right: 5px; 
+					padding-right: 5px;
 				}
 
 				p{
 					font-size: 1em;
 					font-weight: 300;
   				color: #686868;
-					
+
 
 				}
 			}

--- a/src/Shared/components/MemberPreview/MemberPreview.scss
+++ b/src/Shared/components/MemberPreview/MemberPreview.scss
@@ -1,20 +1,8 @@
 $button-color: #7663f6;
 // $button-color: #925ebc;
 
-
-.member-previews-one-column{
-	width: 80%;
-}
-
-.member-previews-two-column{
-	width: 45%;
-}
-
-.member-previews-three-column{
-	width: 30%;
-}
-
 .member-preview {
+	width: 30%;
 	background-color: #fff;
 	border-radius: 7px;
 
@@ -132,8 +120,6 @@ $button-color: #7663f6;
 		margin-bottom: 20px;
   	color: #686868;
 
-
-
 		.member-progress-bar {
 			width: 100%;
 			height: 10px;
@@ -177,9 +163,6 @@ $button-color: #7663f6;
 				border-left: solid 1px #7b5dff;
 				padding-left: 10px;
 
-
-
-
 				.goal-amount {
 
 				}
@@ -187,8 +170,6 @@ $button-color: #7663f6;
 				.goal-label {
 					font-size: 0.55em;
 					font-weight: 300;
-
-
 				}
 			}
 
@@ -217,27 +198,39 @@ $button-color: #7663f6;
 		}
 
 	}
-		.member-donations {
-				font-weight: 300;
+	.member-donations {
+		font-weight: 300;
+	}
+
+	.member-images {
+
+		padding-top: 7px;
+		display: flex;
+		align-items: center;
+
+		img {
+			height: 22px;
+			padding-right: 5px;
 		}
 
-		.member-images {
-
-				padding-top: 7px;
-				display: flex;
-				align-items: center;
-
-				img {
-					height: 22px;
-					padding-right: 5px;
-				}
-
-				p{
-					font-size: 1em;
-					font-weight: 300;
-  				color: #686868;
+		p{
+			font-size: 1em;
+			font-weight: 300;
+			color: #686868;
 
 
-				}
-			}
+		}
+	}
+}
+
+.member-previews-one-column{
+	width: 80%;
+}
+
+.member-previews-two-column{
+	width: 45%;
+}
+
+.member-previews-three-column{
+	width: 30%;
 }

--- a/src/Shared/components/MemberPreview/index.jsx
+++ b/src/Shared/components/MemberPreview/index.jsx
@@ -42,8 +42,11 @@ class MemberPreview extends React.Component {
 			"backgroundColor": donationBarColour
 		}
 
+		let className = "member-preview"
+		if(this.props.className) className += " " + this.props.className
+
 		return (
-			<div className="member-preview" style={previewStyle}>
+			<div className={className} style={previewStyle}>
 				<div className="member-photo-container">
 					{this.createCompletedBanner(percentage)}
 					<Link className="member-link" to={`/member?member_id=${member.id}`}><img className="member-photo" src={this.renderMembersImage()} /></Link>

--- a/src/Shared/components/MemberPreview/index.jsx
+++ b/src/Shared/components/MemberPreview/index.jsx
@@ -31,6 +31,12 @@ class MemberPreview extends React.Component {
 		}
 	}
 
+	getContainerClassName(){
+		let className = "member-preview"
+		if(this.props.className) className += " " + this.props.className
+		return className
+	}
+
 	render() {
 		let previewStyle = this.props.style || {}
 		const {member} = this.props
@@ -42,11 +48,8 @@ class MemberPreview extends React.Component {
 			"backgroundColor": donationBarColour
 		}
 
-		let className = "member-preview"
-		if(this.props.className) className += " " + this.props.className
-
 		return (
-			<div className={className} style={previewStyle}>
+			<div className={this.getMemberPreviewContainerClassName()} style={previewStyle}>
 				<div className="member-photo-container">
 					{this.createCompletedBanner(percentage)}
 					<Link className="member-link" to={`/member?member_id=${member.id}`}><img className="member-photo" src={this.renderMembersImage()} /></Link>

--- a/src/Shared/components/MemberPreview/index.jsx
+++ b/src/Shared/components/MemberPreview/index.jsx
@@ -41,15 +41,13 @@ class MemberPreview extends React.Component {
 		let previewStyle = this.props.style || {}
 		const {member} = this.props
 		const percentage = calcDonationPercentage(member)
-		const textPercentage = percentage.toString() + "%"
-		const donationBarColour = getDonationBarColour(percentage)
 		const donationBarStyles = {
-			"width": textPercentage,
-			"backgroundColor": donationBarColour
+			"width": percentage.toString() + "%",
+			"backgroundColor": getDonationBarColour(percentage)
 		}
 
 		return (
-			<div className={this.getMemberPreviewContainerClassName()} style={previewStyle}>
+			<div className={this.getContainerClassName()} style={previewStyle}>
 				<div className="member-photo-container">
 					{this.createCompletedBanner(percentage)}
 					<Link className="member-link" to={`/member?member_id=${member.id}`}><img className="member-photo" src={this.renderMembersImage()} /></Link>
@@ -68,7 +66,7 @@ class MemberPreview extends React.Component {
 						</div>
 						<div className="progress-details">
 							<div className="member-progress">
-								<p className="progress-percentage">{textPercentage}</p>
+								<p className="progress-percentage">{donationBarStyles.width}</p>
 								<p className="progress-label">RAISED</p>
 							</div>
 							<div className="member-goal">

--- a/src/Shared/components/MemberPreviewBuilder/MemberPreviewBuilder.scss
+++ b/src/Shared/components/MemberPreviewBuilder/MemberPreviewBuilder.scss
@@ -2,5 +2,6 @@
   .member-preview-row{
     display: flex;
     margin-bottom: 50px;
+    justify-content: center;
   }
 }

--- a/src/Shared/components/MemberPreviewBuilder/index.jsx
+++ b/src/Shared/components/MemberPreviewBuilder/index.jsx
@@ -18,7 +18,6 @@ class HelpSomeonePage extends React.Component {
 			let previewStyle = null;
 			if(index % previewsPerLine !== previewsPerLine - 1) previewStyle = {"marginRight": "4.5%"}
 			row.push(<MemberPreview
-				className="member-preview"
 				key={index}
 				style={previewStyle}
 				member={members[index]} />

--- a/src/Shared/components/MemberPreviewBuilder/index.jsx
+++ b/src/Shared/components/MemberPreviewBuilder/index.jsx
@@ -13,12 +13,20 @@ class HelpSomeonePage extends React.Component {
     let previewsPerLine = this.props.previewsPerLine;
 		let memberPreviews = [];
 
+		let previewClassName;
+		switch(previewsPerLine){
+			case 1: previewClassName = "member-previews-one-column"
+			case 2: previewClassName = "member-previews-two-column"
+			case 3: previewClassName = "member-previews-three-column"
+		}
+
 		let row = [];
 		for(let index in members){
 			let previewStyle = null;
 			if(index % previewsPerLine !== previewsPerLine - 1) previewStyle = {"marginRight": "4.5%"}
 			row.push(<MemberPreview
 				key={index}
+				className={previewClassName}
 				style={previewStyle}
 				member={members[index]} />
 			);

--- a/src/Shared/components/MemberPreviewBuilder/index.jsx
+++ b/src/Shared/components/MemberPreviewBuilder/index.jsx
@@ -20,7 +20,7 @@ class HelpSomeonePage extends React.Component {
     let members = this.props.members
     let previewsPerLine = this.props.previewsPerLine;
 		let memberPreviews = [];
-		let previewClassName = this.getRowCountClassName();
+		let previewClassName = this.getRowCountClassName(previewsPerLine);
 
 		let row = [];
 		for(let index in members){

--- a/src/Shared/components/MemberPreviewBuilder/index.jsx
+++ b/src/Shared/components/MemberPreviewBuilder/index.jsx
@@ -8,17 +8,19 @@ import MemberPreview from '../../components/MemberPreview'
 
 class HelpSomeonePage extends React.Component {
 
+	getRowCountClassName(previewsPerLine){
+		switch(previewsPerLine){
+			case 1: return "member-previews-one-column"
+			case 2: return "member-previews-two-column"
+			case 3: return "member-previews-three-column"
+		}
+	}
+
 	buildMemberPreviews(){
     let members = this.props.members
     let previewsPerLine = this.props.previewsPerLine;
 		let memberPreviews = [];
-
-		let previewClassName;
-		switch(previewsPerLine){
-			case 1: previewClassName = "member-previews-one-column"
-			case 2: previewClassName = "member-previews-two-column"
-			case 3: previewClassName = "member-previews-three-column"
-		}
+		let previewClassName = this.getRowCountClassName();
 
 		let row = [];
 		for(let index in members){


### PR DESCRIPTION
Makes it so member previews are centred when there are only one or two displayed in a row. The css to change the sizes based on the number in a row is at the very end of the MemberPreview.scss file if you want to alter them. It works by passing the memberPreview component a prop "className". If this is left blank the default width will be 30% (as set by the css class "member-preview"), else it will be the width set by the class passed to the prop. 