### PR TITLE
Feature/member preview matched icon

### DIFF
--- a/src/Shared/components/MemberPreview/MemberPreview.scss
+++ b/src/Shared/components/MemberPreview/MemberPreview.scss
@@ -11,41 +11,59 @@ $button-color: #7663f6;
 	}
 
 	.member-photo-container{
+		position: relative;
 		width: 100%;
 		border-top-left-radius: 7px;
 		border-top-right-radius: 7px;
 		height: 300px;
-		overflow: hidden;
-		position: relative;
 
-		.completed-banner {
+		.matched-icon{
 			position: absolute;
-			font-size: 0.68em;
 			z-index: 2;
-			width: 200px;
-			text-transform: uppercase;
-			top: 25px;
-			left: -60px;
-			background-color: $button-color;
-			transform: rotate(-45deg);
-			color: #fff;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			height: 30px;
+			right: -15px;
+			top: -15px;
+
+			img{
+				width: 65px;
+				height: 65px;
+			}
 		}
 
- 		.member-photo {
-  		width: 100%;
- 			height: 100%;
- 			object-fit: cover;
- 			object-position: 50% 50%;
+		.overflow-container{
+			overflow: hidden;
+			position: relative;
+			height: 100%;
 
- 			&:hover {
- 				transition: 0.4s ease;
- 				transform: scale(1.05);
- 			}
- 		}
+			.completed-banner {
+				position: absolute;
+				font-size: 0.68em;
+				z-index: 2;
+				width: 200px;
+				text-transform: uppercase;
+				top: 25px;
+				left: -60px;
+				background-color: $button-color;
+				transform: rotate(-45deg);
+				color: #fff;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				height: 30px;
+			}
+
+	 		.member-photo {
+				display: block;
+	  		width: 100%;
+	 			height: 100%;
+	 			object-fit: cover;
+	 			object-position: 50% 50%;
+
+	 			&:hover {
+	 				transition: 0.4s ease;
+	 				transform: scale(1.05);
+	 			}
+	 		}
+		}
 	}
 
 	.member-information {

--- a/src/Shared/components/MemberPreview/index.jsx
+++ b/src/Shared/components/MemberPreview/index.jsx
@@ -12,8 +12,8 @@ class MemberPreview extends React.Component {
 		}
 	}
 
-	createMatchedBanner(){
-		if(this.props.member.sponsors){
+	createMatchedIcon(){
+		if(this.props.member.sponsors.length > 0){
 			return (
 				<div className="matched-icon">
 					<img
@@ -61,7 +61,7 @@ class MemberPreview extends React.Component {
 		return (
 			<div className={this.getContainerClassName()} style={previewStyle}>
 				<div className="member-photo-container">
-					{this.createMatchedBanner()}
+					{this.createMatchedIcon()}
 					<div className="overflow-container">
 						{this.createCompletedBanner(percentage)}
 						<Link className="member-link" to={`/member?member_id=${member.id}`}>

--- a/src/Shared/components/MemberPreview/index.jsx
+++ b/src/Shared/components/MemberPreview/index.jsx
@@ -12,6 +12,18 @@ class MemberPreview extends React.Component {
 		}
 	}
 
+	createMatchedBanner(){
+		if(this.props.member.sponsors){
+			return (
+				<div className="matched-icon">
+					<img
+						src="./images/matchedX2.png"
+						alt="All donations are matched by a sponsor icon"/>
+				</div>
+			)
+		}
+	}
+
 	createDonateButton(percentage) {
 		if (percentage < 100) {
 			return <button className="donate-button">{"Donate"}</button>
@@ -49,8 +61,13 @@ class MemberPreview extends React.Component {
 		return (
 			<div className={this.getContainerClassName()} style={previewStyle}>
 				<div className="member-photo-container">
-					{this.createCompletedBanner(percentage)}
-					<Link className="member-link" to={`/member?member_id=${member.id}`}><img className="member-photo" src={this.renderMembersImage()} /></Link>
+					{this.createMatchedBanner()}
+					<div className="overflow-container">
+						{this.createCompletedBanner(percentage)}
+						<Link className="member-link" to={`/member?member_id=${member.id}`}>
+							<img className="member-photo" src={this.renderMembersImage()} />
+						</Link>
+					</div>
 				</div>
 				<div className="member-information">
 					<Link className="member-link" to={`/member?member_id=${member.id}`}><h3 className="member-name">{member.name}</h3></Link>


### PR DESCRIPTION
Adds matched icon to the top of member preview if they have a sponsor.

Line 16 of src/Shared/components/MemberPreview/index.jsx is where the logic is for if they are visible or not if you want to set it to true and have a look.

That said, if there is a sponsor and a member and sponsor are linked the icon should show up

This will cause the front page to error though (help someone page will work) unless the small rails change I have a pull request for is used as I forgot to add sponsors to featureMemberController while we were working on sponsors last Friday
