### PR TITLE
Fix/featured memberpersistence

### DIFF
--- a/src/NoAuthLandingPage/index.jsx
+++ b/src/NoAuthLandingPage/index.jsx
@@ -49,7 +49,6 @@ class NoAuthLandingPage extends React.Component {
 				return <BeAHero />
 			case 'For Charities':
 				return <ForCharities />
-			default:
 		}
 	}
 

--- a/src/Shared/components/FeaturedMembers/index.jsx
+++ b/src/Shared/components/FeaturedMembers/index.jsx
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux'
 import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
 
-import * as actionCreators from '../../../actions/helpSomeoneActionCreators'
+import * as actionCreators from './../../../actions/featuredMembersActionCreators'
 
 import css from './FeaturedMembers.scss'
 
@@ -33,7 +33,7 @@ class FeaturedMembers extends React.Component {
 }
 
 function mapStateToProps(state, routing) {
-  return { ...state.helpSomeone, ...routing}
+  return { ...state.featuredMembers, ...routing}
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/actions/featuredMembersActionCreators.js
+++ b/src/actions/featuredMembersActionCreators.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+export function getFeaturedMembers() {
+	return {
+		type: 'GET_FEATURED_MEMBERS',
+		payload: axios.get('http://localhost:3000/featured_members')
+	}
+}

--- a/src/actions/helpSomeoneActionCreators.js
+++ b/src/actions/helpSomeoneActionCreators.js
@@ -7,13 +7,6 @@ export function setMembersShown(count) {
 	}
 }
 
-export function getFeaturedMembers() {
-	return {
-		type: 'GET_FEATURED_MEMBERS',
-		payload: axios.get('http://localhost:3000/featured_members')
-	}
-}
-
 export function getMembers() {
 	return {
 		type: 'GET_MEMBERS',

--- a/src/reducers/featuredMembers.js
+++ b/src/reducers/featuredMembers.js
@@ -1,0 +1,19 @@
+const defaultState = {
+  members: [],
+}
+
+function helpSomeone(state = defaultState, action) {
+  console.log("state: ", action.type);
+	switch(action.type) {
+		case 'GET_FEATURED_MEMBERS_PENDING':
+      return {...state, fetching: true}
+  	case 'GET_FEATURED_MEMBERS_REJECTED':
+      return {...state, fetching: true, error: action.payload}
+  	case 'GET_FEATURED_MEMBERS_FULFILLED':
+      return {...state, fetching: true, fetched: true, members: action.payload.data}
+    default:
+			return state
+	}
+}
+
+export default helpSomeone;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,6 +7,7 @@ import howItWorks from './howItWorks'
 import noAuthSubNavigation from './noAuthSubNavigation'
 import charityDashboardSidebar from './charityDashboardSidebar'
 import helpSomeone from './helpSomeone'
+import featuredMembers from './featuredMembers'
 import careButton from './careButton'
 import pricing from './pricing'
 import newMemberProcess from './newMemberProcess'
@@ -23,6 +24,7 @@ const rootReducer = combineReducers({
   noAuthSubNavigation,
   charityDashboardSidebar,
   helpSomeone,
+	featuredMembers,
 	careButton,
   pricing,
   newMemberProcess,


### PR DESCRIPTION
The bug was caused as both section made use of the same array. The help someone page will have rendered the featured members and then I assume when the page render for a second time, after the request for all the members, it just didn't update. 

I made a new reducer and action just for featured members so it can't mix them up. Should fix it.